### PR TITLE
fix: FEV-427 - improve errors message

### DIFF
--- a/src/components/offline/offline.tsx
+++ b/src/components/offline/offline.tsx
@@ -7,12 +7,10 @@ export interface props {
 
 const noInternetTitle = "No Internet Connection";
 const noInternetBody = "Check your network and refresh the page";
-
 const offlineTitle = "Currently not broadcasting";
 const offlineBody = "Video will play once broadcasting starts";
-
-const httpProblemTitle = "There was a problem";
-const httpProblemBody = "Please try to refresh the page";
+const httpProblemTitle = "Something went wrong";
+const httpProblemBody = "Try refreshing the page";
 
 export class Offline extends Component<props> {
     static defaultProps = {

--- a/src/components/offline/offline.tsx
+++ b/src/components/offline/offline.tsx
@@ -5,22 +5,38 @@ export interface props {
     httpError?: boolean;
 }
 
+const noInternetTitle = "No Internet Connection";
+const noInternetBody = "Check your network and refresh the page";
+
+const offlineTitle = "Currently not broadcasting";
+const offlineBody = "Video will play once broadcasting starts";
+
+const httpProblemTitle = "There was a problem";
+const httpProblemBody = "Please try to refresh the page";
+
 export class Offline extends Component<props> {
     static defaultProps = {
         httpError: false
     };
+
     render(props: props) {
         return (
             <div className={styles.offlineWrapper}>
                 <div className={`${styles.offlineIcon} kaltura-live__offline-icon`} />
                 <div>
                     <p className={styles.primaryText}>
-                        {props.httpError ? "No Internet Connection" : "Currently not broadcasting"}
+                        {props.httpError
+                            ? navigator.onLine
+                                ? httpProblemTitle
+                                : noInternetTitle
+                            : offlineTitle}
                     </p>
                     <p className={styles.secondaryText}>
                         {props.httpError
-                            ? "Check your network and refresh the page"
-                            : "Video will play once broadcasting starts"}
+                            ? navigator.onLine
+                                ? httpProblemBody
+                                : noInternetBody
+                            : offlineBody}
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
This PR is about splitting the httpError text messages on the slate to 2 different cases 
If the browser is offline

![image](https://user-images.githubusercontent.com/1536299/70132376-c552ec80-168c-11ea-9bc4-278f3c993505.png)

