### PR TITLE
fix: update live-tag on pause (FEV-788)

### DIFF
--- a/src/decorator/live-decorator.ts
+++ b/src/decorator/live-decorator.ts
@@ -7,6 +7,7 @@ enum EventTypes {
     ENDED = "ended",
     PLAYING = "playing",
     ABORT = "abort",
+    PAUSED = "pause",
 };
 
 const logger = getContribLogger({
@@ -36,7 +37,10 @@ export class KalturaLiveEngineDecorator implements KalturaPlayerTypes.IEngineDec
         ) {
             this._plugin.reloadMedia = true;
         }
-        if (event.type === EventTypes.PLAYING) {
+        if (
+            event.type === EventTypes.PLAYING ||
+            event.type === EventTypes.PAUSED
+        ) {
             this._plugin.updateLiveTag();
         }
         if (event.type === EventTypes.ENDED) {


### PR DESCRIPTION
Current fix trigger _renderLiveTag method that handle proper state of live-tag