### PR TITLE
fix(FEV-758): Player v7 | Live 2.0.7| - Entry view - While the stream is in preview an error will be shown in the player

### DIFF
--- a/src/decorator/live-decorator.ts
+++ b/src/decorator/live-decorator.ts
@@ -27,7 +27,7 @@ export class KalturaLiveEngineDecorator implements KalturaPlayerTypes.IEngineDec
     }
 
     get active(): boolean {
-        return this._plugin.isLiveEntry();
+        return this._plugin.player.isLive();
     }
 
     dispatchEvent(event: any): any {

--- a/src/kaltura-live-plugin.tsx
+++ b/src/kaltura-live-plugin.tsx
@@ -56,7 +56,7 @@ export enum OverlayItemTypes {
 export class KalturaLivePlugin
     implements OnMediaUnload, OnMediaLoad, OnPluginSetup, OnRegisterPresetsComponents {
     private _kalturaClient = new KalturaClient();
-    private _isLiveEntry = false;
+    private _isActive = false;
     private _broadcastState: LiveBroadcastStates = LiveBroadcastStates.Unknown;
     private _wasPlayed = false;
     private _absolutePosition = null;
@@ -144,8 +144,8 @@ export class KalturaLivePlugin
         );
     };
 
-    public isLiveEntry(): boolean {
-        return this._isLiveEntry;
+    public isActive(): boolean {
+        return this._isActive;
     }
 
     public get player() {
@@ -158,7 +158,7 @@ export class KalturaLivePlugin
 
     private _isEntryLiveType = () => {
         if (this._player.isLive()) {
-            this._isLiveEntry = true;
+            this._isActive = true;
             this._player.addEventListener(this._player.Event.FIRST_PLAY, this._handleFirstPlay);
             this._player.addEventListener(
                 this._player.Event.TIMED_METADATA,

--- a/src/middleware/live-middleware.ts
+++ b/src/middleware/live-middleware.ts
@@ -49,7 +49,7 @@ export class KalturaLiveMiddleware extends KalturaPlayer.core.BaseMiddleware {
 
     public load(next: Function): void {
         // if plugin is not active (E.G. in VOD) the middleware will not work
-        if (!this._livePlugin.isLiveEntry()) {
+        if (!this._livePlugin.isActive()) {
             this.callNext(next);
             return;
         }
@@ -66,7 +66,7 @@ export class KalturaLiveMiddleware extends KalturaPlayer.core.BaseMiddleware {
 
     public play(next: Function): void {
         // if plugin is not active (E.G. in VOD) the middleware will not work
-        if (!this._livePlugin.isLiveEntry() || this.isPlayerLive()) {
+        if (!this._livePlugin.isActive() || this.isPlayerLive()) {
             this._isFirstPlay = false;
             this.callNext(next);
             return;


### PR DESCRIPTION
in decorator isLive method returns correct value for entry type