### PR TITLE
fix(FEV-654): Player V7| live 2.0.4| - Edit Entry Page - The audio for the v7 player continues to be heard even if the video has stopped due to disconnecting the computer from internet

### DIFF
--- a/src/kaltura-live-plugin.tsx
+++ b/src/kaltura-live-plugin.tsx
@@ -240,7 +240,7 @@ export class KalturaLivePlugin
                 ended: ended
             }
         });
-        if (receivedState === LiveBroadcastStates.Error) {
+        if (receivedState === LiveBroadcastStates.Error && this._player.paused) {
             this._manageOfflineSlate(OverlayItemTypes.HttpError);
             return;
         }
@@ -286,10 +286,8 @@ export class KalturaLivePlugin
         }
         switch (type) {
             case OverlayItemTypes.NoLongerLive:
-                if (!this.player.isOnLiveEdge() && !this.player.ended) {
-                    this._currentOverlay = null;
-                } else {
-                    this._initTimeout();
+                this._initTimeout();
+                if (this.player.ended) {
                     this._currentOverlay = this._contribServices.overlayManager.add({
                         label: "no-longer-live-overlay",
                         position: OverlayPositions.PlayerArea,
@@ -388,9 +386,7 @@ export class KalturaLivePlugin
                 this._activeRequest = false;
                 this._isLive = false;
                 this._isPreview = false;
-                if (this._player.paused) {
-                    this.handleLiveStatusReceived(LiveBroadcastStates.Error);
-                }
+                this.handleLiveStatusReceived(LiveBroadcastStates.Error);
                 logger.error("Failed to call isLive API", {
                     method: "updateLiveStatus",
                     data: {


### PR DESCRIPTION
1) prevent set "No longer live" slate when stream already stopped but playback still playing media from player cache.
2) condition for "HttpError" slate moved into "handleLiveStatusReceived" method to clean up code.