### PR TITLE
fix(FEV-777):  Safari - Sometimes when the stream is restarted it will be played while showing the offline label

### DIFF
--- a/src/components/live-tag/live-tag.scss
+++ b/src/components/live-tag/live-tag.scss
@@ -1,4 +1,6 @@
 .live-tag {
+    display: inline-block;
+    margin-top: 4px;
     padding: 3px 4px;
     opacity: 0.94;
     border-radius: 4px;
@@ -18,13 +20,5 @@
     }
     &.clickable {
         cursor: pointer;
-    }
-}
-
-
-:global {
-    .playkit-player .playkit-bottom-bar .playkit-left-controls div[data-contrib-injected="kaltura-live-tag"] {
-        display: inline-block;
-        margin-top: 4px;
     }
 }

--- a/src/components/live-tag/live-tag.tsx
+++ b/src/components/live-tag/live-tag.tsx
@@ -1,56 +1,56 @@
-import { h, Component } from "preact";
-import * as styles from "./live-tag.scss";
+import {h, Component} from 'preact';
+import * as styles from './live-tag.scss';
 
-export interface props {
-    isLive: boolean;
-    isPreview: boolean;
-    isOnLiveEdge: boolean;
-    onClick: () => void;
+export enum LiveTagStates {
+  Offline = 'Offline',
+  Live = 'Live',
+  Preview = 'Preview',
 }
 
-export class LiveTag extends Component<props> {
-    private _getStyles = () => {
-        const { isOnLiveEdge, isPreview, isLive } = this.props;
-        if (isOnLiveEdge && isLive) {
-            return styles.live;
-        }
-        if (isOnLiveEdge && isPreview) {
-            return styles.preview;
-        }
-        return styles.offline;
-    };
-    private _getLabel = () => {
-        const { isPreview, isLive } = this.props;
-        if (isPreview) {
-            return "preview";
-        }
-        if (isLive) {
-            return "live";
-        }
-        return "offline";
-    };
+export interface LiveTagProps {
+  state: LiveTagStates;
+  isOnLiveEdge: boolean;
+  onClick: () => void;
+}
 
-    private _onClick = (): void => {
-        const { isOnLiveEdge, onClick } = this.props;
-        if (!isOnLiveEdge) {
-            onClick();
-        }
-    };
-
-    render(props: props) {
-        return (
-            <div
-                role="button"
-                tab-index={0}
-                className={[
-                    styles.liveTag,
-                    this._getStyles(),
-                    !props.isOnLiveEdge ? styles.clickable : ""
-                ].join(" ")}
-                onClick={this._onClick}
-            >
-                {this._getLabel()}
-            </div>
-        );
+export class LiveTag extends Component<LiveTagProps> {
+  shouldComponentUpdate(nextProps: LiveTagProps) {
+    return (
+      this.props.state !== nextProps.state ||
+      this.props.isOnLiveEdge !== nextProps.isOnLiveEdge
+    );
+  }
+  private _getStyles = () => {
+    const {isOnLiveEdge, state} = this.props;
+    if (isOnLiveEdge && state === LiveTagStates.Live) {
+      return styles.live;
     }
+    if (isOnLiveEdge && state === LiveTagStates.Preview) {
+      return styles.preview;
+    }
+    return styles.offline;
+  };
+
+  private _onClick = (): void => {
+    const {isOnLiveEdge, onClick} = this.props;
+    if (!isOnLiveEdge) {
+      onClick();
+    }
+  };
+
+  render(props: LiveTagProps) {
+    return (
+      <div
+        role="button"
+        tab-index={0}
+        className={[
+          styles.liveTag,
+          this._getStyles(),
+          !props.isOnLiveEdge ? styles.clickable : '',
+        ].join(' ')}
+        onClick={this._onClick}>
+        {props.state}
+      </div>
+    );
+  }
 }


### PR DESCRIPTION
1) use player ui api to render live-tag component
2) simplify logic of live-tag state
3) refactored live-tag component to avoid unnecessary re-renders