### PR TITLE
FEV-787 - UI - there is not enough space between the 'Seek Forward' button and the 'Live' label

### DIFF
--- a/src/components/live-tag/live-tag.scss
+++ b/src/components/live-tag/live-tag.scss
@@ -6,6 +6,7 @@
     color: #ffffff;
     font-size: 15px;
     text-transform: uppercase;
+    margin: 0 12px;
     &.preview {
         background-color: #f9a71b;;
         color: #000000;

--- a/src/components/live-tag/live-tag.scss
+++ b/src/components/live-tag/live-tag.scss
@@ -1,6 +1,6 @@
 .live-tag {
     display: inline-block;
-    margin-top: 4px;
+    margin: 4px 12px;
     padding: 3px 4px;
     opacity: 0.94;
     border-radius: 4px;
@@ -8,7 +8,6 @@
     color: #ffffff;
     font-size: 15px;
     text-transform: uppercase;
-    margin: 0 12px;
     &.preview {
         background-color: #f9a71b;;
         color: #000000;


### PR DESCRIPTION
Fix styles for live-tag

<img width="325" alt="Screen Shot 2021-01-29 at 9 27 15 PM" src="https://user-images.githubusercontent.com/51074448/106318578-cd9abd80-6278-11eb-9cc6-6e524c1e8d13.png">
