### PR TITLE
FEV-660 - Player V7| live 2.0.4| - Low network conditions - Live does not return to the correct time after low network conditions are removed

### DIFF
--- a/src/decorator/live-decorator.ts
+++ b/src/decorator/live-decorator.ts
@@ -9,6 +9,7 @@ enum EventTypes {
     ABORT = "abort",
     PAUSED = "pause",
     METADATA = "timedmetadata",
+    SEEKING = "seeking",
 };
 
 const logger = getContribLogger({
@@ -32,9 +33,15 @@ export class KalturaLiveEngineDecorator implements KalturaPlayerTypes.IEngineDec
     }
 
     dispatchEvent(event: any): any {
-        console.log(event)
         if (event.type === EventTypes.METADATA) {
             this._plugin.handleTimedMetadata(event);
+        }
+        if (event.type === EventTypes.SEEKING) {
+            // player.js should set _isOnLiveEdge property before updateLiveTag executes:
+            // https://github.com/kaltura/playkit-js/blob/master/src/player.js#L1696-L1700
+            setTimeout(() => {
+                this._plugin.updateLiveTag();
+            });
         }
         if (
             event.type === EventTypes.ENDED ||

--- a/src/decorator/live-decorator.ts
+++ b/src/decorator/live-decorator.ts
@@ -9,7 +9,7 @@ enum EventTypes {
     ABORT = "abort",
     PAUSED = "pause",
     METADATA = "timedmetadata",
-    SEEKING = "seeking",
+    SEEKED = "seeked",
 };
 
 const logger = getContribLogger({
@@ -36,12 +36,10 @@ export class KalturaLiveEngineDecorator implements KalturaPlayerTypes.IEngineDec
         if (event.type === EventTypes.METADATA) {
             this._plugin.handleTimedMetadata(event);
         }
-        if (event.type === EventTypes.SEEKING) {
-            // player.js should set _isOnLiveEdge property before updateLiveTag executes:
+        if (event.type === EventTypes.SEEKED) {
+            // check _isOnLiveEdge property after 'SEEKING' event happened
             // https://github.com/kaltura/playkit-js/blob/master/src/player.js#L1696-L1700
-            setTimeout(() => {
-                this._plugin.updateLiveTag();
-            });
+            this._plugin.updateLiveTag();
         }
         if (
             event.type === EventTypes.ENDED ||

--- a/src/decorator/live-decorator.ts
+++ b/src/decorator/live-decorator.ts
@@ -8,6 +8,7 @@ enum EventTypes {
     PLAYING = "playing",
     ABORT = "abort",
     PAUSED = "pause",
+    METADATA = "timedmetadata",
 };
 
 const logger = getContribLogger({
@@ -31,6 +32,10 @@ export class KalturaLiveEngineDecorator implements KalturaPlayerTypes.IEngineDec
     }
 
     dispatchEvent(event: any): any {
+        console.log(event)
+        if (event.type === EventTypes.METADATA) {
+            this._plugin.handleTimedMetadata(event);
+        }
         if (
             event.type === EventTypes.ENDED ||
             event.type === EventTypes.ABORT

--- a/src/kaltura-live-plugin.tsx
+++ b/src/kaltura-live-plugin.tsx
@@ -87,10 +87,6 @@ export class KalturaLivePlugin
     onMediaUnload(): void {
         this._resetTimeout();
         this._player.removeEventListener(this._player.Event.FIRST_PLAY, this._handleFirstPlay);
-        this._player.removeEventListener(
-            this._player.Event.TIMED_METADATA,
-            this._handleTimedMetadata
-        );
     }
 
     public updateLiveTag() {
@@ -132,10 +128,6 @@ export class KalturaLivePlugin
             this.updateLiveTag();
             this._isActive = true;
             this._player.addEventListener(this._player.Event.FIRST_PLAY, this._handleFirstPlay);
-            this._player.addEventListener(
-                this._player.Event.TIMED_METADATA,
-                this._handleTimedMetadata
-            );
             this._player.configure({
                 plugins: { kava: { tamperAnalyticsHandler: this._tamperAnalyticsHandler } }
             });
@@ -143,7 +135,7 @@ export class KalturaLivePlugin
         }
     };
 
-    private _handleTimedMetadata = (e: any) => {
+    public handleTimedMetadata = (e: any) => {
         this.updateLiveTag();
         if (!e || !e.payload || !e.payload.cues || !e.payload.cues.length) {
             this._absolutePosition = null;


### PR DESCRIPTION
1) optimization: remove listener and handle 'timedmetadata' event in decorator
2) optimization: update live-tag on 'seeking' event like player.js does
3) prevent unnecessary re-render of custom live-tag