### PR TITLE
Player v7 | Live 2.1.1| - Sometimes, preview and live labels wrongly displayed as DVR (gray background color)

### DIFF
--- a/src/components/live-tag/live-tag.tsx
+++ b/src/components/live-tag/live-tag.tsx
@@ -101,7 +101,6 @@ export class LiveTag extends Component<LiveTagProps, LiveTagState> {
   };
 
   render() {
-    const { isOnLiveEdge, liveTagState } = this.state;
     const { behindLiveEdge, liveTagState } = this.state;
     return (
       <div

--- a/src/components/live-tag/live-tag.tsx
+++ b/src/components/live-tag/live-tag.tsx
@@ -13,7 +13,7 @@ interface LiveTagProps {
 
 interface LiveTagState {
   liveTagState: LiveTagStates;
-  isOnLiveEdge: boolean;
+  behindLiveEdge: boolean;
 }
 
 interface Context {
@@ -21,22 +21,22 @@ interface Context {
 }
 
 export class LiveTag extends Component<LiveTagProps, LiveTagState> {
-  constructor(props: LiveTagProps, context: Context) {
+  constructor(props: LiveTagProps, { player }: Context) {
     super();
     this.state = {
       liveTagState: props.liveTagState,
-      isOnLiveEdge: context.player.isOnLiveEdge(),
+      behindLiveEdge: false,
     };
   }
 
   shouldComponentUpdate(nextProps: LiveTagProps, nextState: LiveTagState) {
     return (
       nextState.liveTagState !== this.state.liveTagState ||
-      nextState.isOnLiveEdge !== this.state.isOnLiveEdge
+      nextState.behindLiveEdge !== this.state.behindLiveEdge
     );
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.context.player.addEventListener(
       this.context.player.Event.SEEKED,
       this._updateIsOnLiveEdge
@@ -73,9 +73,10 @@ export class LiveTag extends Component<LiveTagProps, LiveTagState> {
 
   private _updateIsOnLiveEdge = () => {
     this.setState({
-      isOnLiveEdge: this.context.player.paused
-        ? false
-        : this.context.player.isOnLiveEdge(),
+      // condition taken from https://github.com/kaltura/playkit-js-ui/blob/master/src/components/live-tag/live-tag.js#L73
+      behindLiveEdge:
+        this.context.player.paused ||
+        (this.context.player.isDvr && !this.context.player.isOnLiveEdge()),
     });
   };
 
@@ -89,11 +90,11 @@ export class LiveTag extends Component<LiveTagProps, LiveTagState> {
   };
 
   private _getStyles = () => {
-    const { isOnLiveEdge, liveTagState } = this.state;
-    if (isOnLiveEdge && liveTagState === LiveTagStates.Live) {
+    const { behindLiveEdge, liveTagState } = this.state;
+    if (!behindLiveEdge && liveTagState === LiveTagStates.Live) {
       return styles.liveEdge;
     }
-    if (isOnLiveEdge && liveTagState === LiveTagStates.Preview) {
+    if (!behindLiveEdge && liveTagState === LiveTagStates.Preview) {
       return styles.previewEdge;
     }
     return styles.nonEdge;
@@ -101,6 +102,7 @@ export class LiveTag extends Component<LiveTagProps, LiveTagState> {
 
   render() {
     const { isOnLiveEdge, liveTagState } = this.state;
+    const { behindLiveEdge, liveTagState } = this.state;
     return (
       <div
         role="button"
@@ -108,7 +110,7 @@ export class LiveTag extends Component<LiveTagProps, LiveTagState> {
         className={[
           styles.liveTag,
           this._getStyles(),
-          !isOnLiveEdge ? styles.clickable : '',
+          behindLiveEdge ? styles.clickable : '',
         ].join(' ')}
         onClick={this._seekToLiveEdge}>
         {liveTagState}

--- a/src/components/live-tag/live-tag.tsx
+++ b/src/components/live-tag/live-tag.tsx
@@ -42,10 +42,6 @@ export class LiveTag extends Component<LiveTagProps, LiveTagState> {
       this._updateIsOnLiveEdge
     );
     this.context.player.addEventListener(
-      this.context.player.Event.PLAYING,
-      this._updateIsOnLiveEdge
-    );
-    this.context.player.addEventListener(
       this.context.player.Event.PAUSE,
       this._updateIsOnLiveEdge
     );
@@ -53,10 +49,6 @@ export class LiveTag extends Component<LiveTagProps, LiveTagState> {
   componentWillUnmount() {
     this.context.player.removeEventListener(
       this.context.player.Event.SEEKED,
-      this._updateIsOnLiveEdge
-    );
-    this.context.player.removeEventListener(
-      this.context.player.Event.PLAYING,
       this._updateIsOnLiveEdge
     );
     this.context.player.removeEventListener(

--- a/src/kaltura-live-plugin.tsx
+++ b/src/kaltura-live-plugin.tsx
@@ -58,7 +58,7 @@ export class KalturaLivePlugin
     private _absolutePosition = null;
     private _isLiveApiCallTimeout: any = null;
     private _currentOverlay: OverlayItem | null = null;
-    private _liveTagState: LiveTagStates = LiveTagStates.Offline;
+    private _liveTagState: LiveTagStates = LiveTagStates.Live;
     private _activeRequest = false;
     public reloadMedia = false;
     private _liveTag = createRef<LiveTag>();


### PR DESCRIPTION
set same condition for live-tag styles as player-ui live tag has