### PR TITLE
FEV-760 - Player V7| live 2.0.7| Edit WC page- VOD continues to be played on the player after moving from offline to preview

### DIFF
--- a/src/kaltura-live-plugin.tsx
+++ b/src/kaltura-live-plugin.tsx
@@ -195,14 +195,14 @@ export class KalturaLivePlugin implements OnMediaUnload, OnPluginDestroy {
 
     private _attachMediaSource = () => {
         this._attachMedia = false;
-        this._player.addEventListener(this._player.Event.PLAYING, this._restoreLiveEdge);
+        this._player.addEventListener(this._player.Event.CAN_PLAY, this._restoreLiveEdge);
         this._player.attachMediaSource();
         this._player.play();
     }
 
     private _restoreLiveEdge = () => {
         this._player.seekToLiveEdge();
-        this._player.removeEventListener(this._player.Event.PLAYING, this._restoreLiveEdge);
+        this._player.removeEventListener(this._player.Event.CAN_PLAY, this._restoreLiveEdge);
     }
 
     private _resetTimeout = () => {


### PR DESCRIPTION
1) use player API to attach and detach media (restore after end event handled);
2) use `player.Event.PLAYING` event to restore live edge after media got attached.