### PR TITLE
fix(FEV-1128): Live slate is displayed for non-live entries when reaching the end of the video

### DIFF
--- a/src/decorator/live-decorator.ts
+++ b/src/decorator/live-decorator.ts
@@ -54,9 +54,11 @@ export class KalturaLiveEngineDecorator
   };
 
   private _handleEnd = () => {
-    this._plugin.detachMediaSource();
-    this._plugin.updateLiveStatus();
-    this._ended = true;
+    if (this._plugin.isMediaLive) {
+      this._plugin.detachMediaSource();
+      this._plugin.updateLiveStatus();
+      this._ended = true;
+    }
   };
 
   private _handleMediaLoaded = () => {


### PR DESCRIPTION
prevent get details call for non-live entry