### PR TITLE
fix(FEV-1135): offline slate doesn't appears for live media with DVR

### DIFF
--- a/src/decorator/live-decorator.ts
+++ b/src/decorator/live-decorator.ts
@@ -48,7 +48,7 @@ export class KalturaLiveEngineDecorator
 
   private _handleError = (e: any) => {
     if (e.payload.severity === this._plugin.player.Error.Severity.CRITICAL) {
-      this._plugin.reloadMedia = true;
+      this._plugin.playerHasError = true;
     }
     this._hadError = true;
   };

--- a/src/kaltura-live-plugin.tsx
+++ b/src/kaltura-live-plugin.tsx
@@ -44,7 +44,7 @@ export class KalturaLivePlugin implements OnMediaUnload, OnPluginDestroy {
     private _isLiveApiCallTimeout: any = null;
     private _liveTagState: LiveTagStates = LiveTagStates.Live;
     private _activeRequest = false;
-    public reloadMedia = false;
+    public playerHasError = false;
     private _mediaDetached = false;
     private _liveTag = createRef<LiveTag>();
     private _offlineSlate = createRef<OfflineSlate>();
@@ -178,7 +178,7 @@ export class KalturaLivePlugin implements OnMediaUnload, OnPluginDestroy {
     };
 
     private _loadMedia = () => {
-        this.reloadMedia = false;
+        this.playerHasError = false;
         const player: any = KalturaPlayer.getPlayer(this._player.config.targetId);
         const entryId = this._player.config.sources.id;
         player?.configure({ playback: { autoplay: true }});
@@ -255,7 +255,7 @@ export class KalturaLivePlugin implements OnMediaUnload, OnPluginDestroy {
         }
 
         if (receivedState === LiveBroadcastStates.Live) {
-            if (this.reloadMedia) {
+            if (this.playerHasError) {
                 logger.info("Player got error but stream is Live now. Reload media", {
                     method: "handleLiveStatusReceived"
                 });
@@ -284,7 +284,7 @@ export class KalturaLivePlugin implements OnMediaUnload, OnPluginDestroy {
         this._initTimeout();
         switch (type) {
             case OfflineTypes.NoLongerLive:
-                if (!this._player.isDvr() || this._mediaDetached || this.reloadMedia) {
+                if (!this._player.isDvr() || this._mediaDetached || this.playerHasError) {
                     this._updateOfflineSlate(OfflineTypes.NoLongerLive);
                 }
                 break;

--- a/src/kaltura-live-plugin.tsx
+++ b/src/kaltura-live-plugin.tsx
@@ -284,7 +284,7 @@ export class KalturaLivePlugin implements OnMediaUnload, OnPluginDestroy {
         this._initTimeout();
         switch (type) {
             case OfflineTypes.NoLongerLive:
-                if (!this._player.isDvr() || this._attachMedia) {
+                if (!this._player.isDvr() || this._attachMedia || this.reloadMedia) {
                     this._updateOfflineSlate(OfflineTypes.NoLongerLive);
                 }
                 break;


### PR DESCRIPTION
display offline slate if error handled by live-decorator