### PR TITLE
fix(LIV-758): simulive to live and failovers confs tuning

### DIFF
--- a/src/kaltura-live-plugin.tsx
+++ b/src/kaltura-live-plugin.tsx
@@ -41,13 +41,16 @@ export class KalturaLivePlugin extends KalturaPlayer.core.BasePlugin implements 
     super(name, player, config);
     player.configure({
       network: {
-        maxStaleLevelReloads: 12,
-        playback: {
-          options: {
-            html5: {
-              hls: {
-                levelLoadingMaxRetryTimeout: 750
-              }
+        maxStaleLevelReloads: 8
+      },
+      playback: {
+        options: {
+          html5: {
+            hls: {
+              levelLoadingMaxRetryTimeout: 750
+            },
+            native: {
+              heartbeatTimeout: 10000
             }
           }
         }


### PR DESCRIPTION
this PR contains tuned values to improve the failover of primary/secondary and simulive to live (and live to simulive):

**_"maxStaleLevelReloads"_**
 changed from 12 to 8 - as BE fixed to get informed about "dead" stream sooner than in the past - so we can reduce this value and get a better experience
**_"heartbeatTimeout"_**
 conf of "native" reduced to improve failover in Safari browser. before this change - the value was 30 sec- and it caused 30 seconds of buffering in case of failover
**_"levelLoadingMaxRetryTimeout"_**
 moved to the appropriate place (it was inside the "network" object and didn't affect)