### PR TITLE
fix(LIV-905): fix mpeg-dash restart issues

### DIFF
--- a/src/kaltura-live-plugin.tsx
+++ b/src/kaltura-live-plugin.tsx
@@ -51,6 +51,11 @@ export class KalturaLivePlugin extends KalturaPlayer.core.BasePlugin implements 
             },
             native: {
               heartbeatTimeout: 10000
+            },
+            dash: {
+              streaming: {
+                jumpLargeGaps: true
+              }
             }
           }
         }


### PR DESCRIPTION
in case of DVR on - fast restart of the stream will cause dash playback to get stuck. this configuration should be added to shaka in order to solve it.
reference: https://github.com/google/shaka-player/issues/555#issuecomment-294552711