### PR TITLE
fix(FEV-1403): When VOD source is shorter than the simulive window, the configured DVR will replay the last 10-15 seconds until page refresh is done

### DIFF
--- a/src/decorator/live-decorator.ts
+++ b/src/decorator/live-decorator.ts
@@ -58,14 +58,8 @@ export class KalturaLiveEngineDecorator implements KalturaPlayerTypes.IEngineDec
 
   dispatchEvent(event: any): any {
     if (event.type === this._plugin.player.Event.ENDED) {
-      if (this._plugin.allStreamsStopped){
-        // primary and secondary streams are stopped - live has ended and the player should dispatch the playbackended event
-        this._ended = true;
-      } else {
-        // at least one stream is still broadcasting (maybe switch between primary / secondary streams) - keep alive
-        this._ended = false;
-        return true; // this prevents the ended event propagation to the player thus preventing the playbackended event from being dispatched
-      }
+      this._ended = false;
+      return true;
     }
     if (event.type === 'error' && event.payload && event.payload.code && HANDLED_ERRORS.indexOf(event.payload.code) > -1) {
       this._logger.info(`Kaltura live-decorator prevented interrupted error ${event.payload.code}`);

--- a/src/kaltura-live-plugin.tsx
+++ b/src/kaltura-live-plugin.tsx
@@ -28,7 +28,7 @@ export enum KalturaEntryServerNodeStatus {
   taskPending = 5,
   taskProcessing = 7,
   taskQueued = 6,
-  taskUploading = 8,
+  taskUploading = 8
 }
 
 // @ts-ignore
@@ -43,7 +43,6 @@ export class KalturaLivePlugin extends KalturaPlayer.core.BasePlugin implements 
   private _activeRequest = false;
   public playerHasError = false;
   private _mediaDetached = false;
-  public allStreamsStopped = false;
   private _liveTag = createRef<LiveTag>();
   private _offlineSlate = createRef<OfflineSlate>();
 
@@ -295,15 +294,32 @@ export class KalturaLivePlugin extends KalturaPlayer.core.BasePlugin implements 
             this._initTimeout();
             return;
           }
-          this.allStreamsStopped = streamDetails.primaryStreamStatus === KalturaEntryServerNodeStatus.stopped && streamDetails.secondaryStreamStatus === KalturaEntryServerNodeStatus.stopped;
-          switch (streamDetails.broadcastStatus) {
+          const {primaryStreamStatus, secondaryStreamStatus, broadcastStatus} = streamDetails;
+          this.logger.info(
+            `LiveStreamGetDetails received:
+              Primary stream: ${primaryStreamStatus};
+              Secondary stream: ${secondaryStreamStatus};
+              Broadcast Status: ${broadcastStatus};
+            `
+          );
+
+          const streamPlayable = [primaryStreamStatus, secondaryStreamStatus].some(
+            streamStatus => streamStatus === KalturaEntryServerNodeStatus.playable
+          );
+
+          const isSimulive = !streamPlayable && broadcastStatus === KalturaLiveStreamBroadcastStatus.live;
+          const isSimuliveEnded = isSimulive && this._mediaDetached;
+
+          if (isSimuliveEnded || broadcastStatus === KalturaLiveStreamBroadcastStatus.offline) {
+            this._updateLiveTag(LiveTagStates.Offline);
+            this.handleLiveStatusReceived(LiveBroadcastStates.Offline);
+            return;
+          }
+
+          switch (broadcastStatus) {
             case KalturaLiveStreamBroadcastStatus.live:
               this._updateLiveTag(LiveTagStates.Live);
               this.handleLiveStatusReceived(LiveBroadcastStates.Live);
-              break;
-            case KalturaLiveStreamBroadcastStatus.offline:
-              this._updateLiveTag(LiveTagStates.Offline);
-              this.handleLiveStatusReceived(LiveBroadcastStates.Offline);
               break;
             case KalturaLiveStreamBroadcastStatus.preview:
               if (this.config.checkLiveWithKs) {
@@ -315,7 +331,6 @@ export class KalturaLivePlugin extends KalturaPlayer.core.BasePlugin implements 
               }
               break;
           }
-          this.logger.info('LiveStreamGetDetails received. data.broadcastStatus ' + streamDetails.broadcastStatus);
         }
       })
       .catch((e: any) => {
@@ -340,7 +355,6 @@ export class KalturaLivePlugin extends KalturaPlayer.core.BasePlugin implements 
     this.player.attachMediaSource();
     this._resetTimeout();
     this.isMediaLive = false;
-    this.allStreamsStopped = false;
     this.eventManager.unlisten(this.player, this.player.Event.FIRST_PLAY, this._handleFirstPlay);
     this.eventManager.unlisten(this.player, this.player.Event.TIMED_METADATA, this.handleTimedMetadata);
     this.eventManager.unlisten(this.player, this.player.Event.MEDIA_LOADED, this._handleMediaLoaded);


### PR DESCRIPTION
proper handle stream status for simulive entry