### PR TITLE
fix(FEV-1205): DVR play stops without reaching the end of the stream if the stream is stopped while the player is behind live edge

### DIFF
--- a/src/kaltura-live-plugin.tsx
+++ b/src/kaltura-live-plugin.tsx
@@ -71,7 +71,7 @@ export class KalturaLivePlugin extends KalturaPlayer.core.BasePlugin implements 
   loadMedia(): void {
     this.player.configure({
       network: {
-        maxStaleLevelReloads: 8
+        maxStaleLevelReloads: 19 // more details in https://kaltura.atlassian.net/browse/FEV-1205
       },
       playback: {
         options: {


### PR DESCRIPTION
 change Kaltura-player network configuration (endlist manifest)