### PR TITLE
fix(FEV-1601): When a live stream with DVR OFF is stopped there is a spinner on top of the slate

### DIFF
--- a/src/components/no-longer-live/no-longer-live.scss
+++ b/src/components/no-longer-live/no-longer-live.scss
@@ -3,7 +3,7 @@
   position: absolute;
   top: 0;
   right: 0;
-  z-index: 6; // overlap spinner and replay button
+  z-index: $slate-zindex;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/components/no-longer-live/no-longer-live.scss
+++ b/src/components/no-longer-live/no-longer-live.scss
@@ -3,7 +3,7 @@
   position: absolute;
   top: 0;
   right: 0;
-  z-index: 5; // overlap spinner and replay button
+  z-index: 6; // overlap spinner and replay button
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/components/offline/offline.scss
+++ b/src/components/offline/offline.scss
@@ -4,7 +4,7 @@
   position: absolute;
   top: 0;
   right: 0;
-  z-index: 5; // overlap spinner and replay button
+  z-index: 6; // overlap spinner and replay button
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/components/offline/offline.scss
+++ b/src/components/offline/offline.scss
@@ -4,7 +4,7 @@
   position: absolute;
   top: 0;
   right: 0;
-  z-index: 6; // overlap spinner and replay button
+  z-index: $slate-zindex;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -1,3 +1,5 @@
 $text-color: #999999;
 $layout-color: #000000;
 $font-family: sans-serif;
+
+$slate-zindex: 6; // overlap spinner and replay button


### PR DESCRIPTION
increase z-index for offline overlays