### PR TITLE
fix(SUP-41353): Future live event in a playlist will remove the access to the side panel

### DIFF
--- a/src/kaltura-live-plugin.tsx
+++ b/src/kaltura-live-plugin.tsx
@@ -370,7 +370,7 @@ export class KalturaLivePlugin extends KalturaPlayer.core.BasePlugin implements 
         break;
     }
     this.sidePanelsManager?.componentsRegistry?.forEach((plugin: any, key: number) => {
-      if (plugin.isActive) {
+      if (plugin.item.label !== 'Playlist' && plugin.isActive) {
         this.sidePanelsManager.deactivateItem(key);
       }
     });


### PR DESCRIPTION
**Issue:**
When there is live entry in playlist, and the live entry is currently not broadcasting the playlist panel is closed after few seconds so user can't navigate in the playlist until the live will stream again.

**Fix:**
Do not deactivate the playlist panel when entry is offline

Solves [SUP-41353](https://kaltura.atlassian.net/browse/SUP-41353)

[SUP-41353]: https://kaltura.atlassian.net/browse/SUP-41353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ