### PR TITLE
fix(FEC-13353): disable live viewers feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,4 +207,4 @@ One can also choose to hide the text message on the slate.
 >
 > ##### Type: `boolean`
 >
-> ##### Default: `true`
+> ##### Default: `false`

--- a/cypress/e2e/kaltura-live.cy.ts
+++ b/cypress/e2e/kaltura-live.cy.ts
@@ -196,7 +196,7 @@ describe('Kaltura-live plugin', () => {
     });
     it('should render liveViewers component', () => {
       mockKalturaBe('live.json', 'live-stream.json');
-      loadPlayer().then(() => {
+      loadPlayer({showLiveViewers: true}).then(() => {
         cy.get('[data-testid="kaltura-live_liveViewers"]').should('exist');
         cy.get('[data-testid="kaltura-live_liveViewersNumber"]').should('exist').should('have.text', '0');
         cy.get('[data-testid="kaltura-live_liveViewersNumber"]').should('have.text', '3,124');

--- a/src/kaltura-live-plugin.tsx
+++ b/src/kaltura-live-plugin.tsx
@@ -70,7 +70,7 @@ export class KalturaLivePlugin extends KalturaPlayer.core.BasePlugin implements 
     isLiveInterval: 10,
     bufferingFailoverTimeout: 10,
     offlineSlateWithoutText: false,
-    showLiveViewers: true
+    showLiveViewers: false
   };
 
   constructor(name: string, player: KalturaPlayerTypes.Player, config: LivePluginConfig) {


### PR DESCRIPTION
set default value of `showLiveViewers` configuration to `false`.

[FEC-13353](https://kaltura.atlassian.net/browse/FEC-13353)

[FEC-13353]: https://kaltura.atlassian.net/browse/FEC-13353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ