### PR TITLE
fix(FEC-14353): When live viewers count equals to zero do not display viewers count

### DIFF
--- a/cypress/e2e/kaltura-live.cy.ts
+++ b/cypress/e2e/kaltura-live.cy.ts
@@ -197,9 +197,11 @@ describe('Kaltura-live plugin', () => {
     it('should render liveViewers component', () => {
       mockKalturaBe('live.json', 'live-stream.json');
       loadPlayer({showLiveViewers: true}).then(() => {
+        // initially, the component should not render since liveViewers is 0
+        cy.get('[data-testid="kaltura-live_liveViewers"]').should('not.exist');
+        // the component should render since liveViewers is bigger than 0
         cy.get('[data-testid="kaltura-live_liveViewers"]').should('exist');
-        cy.get('[data-testid="kaltura-live_liveViewersNumber"]').should('exist').should('have.text', '0');
-        cy.get('[data-testid="kaltura-live_liveViewersNumber"]').should('have.text', '3,124');
+        cy.get('[data-testid="kaltura-live_liveViewersNumber"]').should('exist').should('have.text', '3,124');
       });
     });
   });

--- a/src/components/live-viewers/live-viewers-manager.tsx
+++ b/src/components/live-viewers/live-viewers-manager.tsx
@@ -59,7 +59,7 @@ export class LiveViewersManager {
     const entryId = this._player.config.sources.id;
     const requestUrl: string = this._baseRequestUrl.replace(ENTRY_ID_URL_PLACEHOLDER, entryId);
     const liveViewers: number | null = await this._getLiveViewers(requestUrl);
-    if (typeof liveViewers === 'number') {
+    if (typeof liveViewers === 'number' && liveViewers > 0) {
       this._liveViewersRef?.current?.updateLiveViewers(liveViewers);
     }
   };

--- a/src/components/live-viewers/live-viewers.tsx
+++ b/src/components/live-viewers/live-viewers.tsx
@@ -31,10 +31,12 @@ export class LiveViewers extends Component<{}, LiveViewersState> {
   render() {
     return (
       <div className={styles.liveViewersContainer}>
-        <div className={styles.liveViewers} data-testid="kaltura-live_liveViewers">
-          <LiveViewersIcon/>
-          <span data-testid="kaltura-live_liveViewersNumber">{this.state.liveViewers}</span>
-        </div>
+        {this.state.liveViewers !== "0" && (
+            <div className={styles.liveViewers} data-testid="kaltura-live_liveViewers">
+              <LiveViewersIcon />
+              <span data-testid="kaltura-live_liveViewersNumber">{this.state.liveViewers}</span>
+            </div>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
### Description of the Changes

- Rendering the live viewers number only when the number is different from 0.
- Only update live viewers count when the number is bigger than 0.

[FEC-14353](https://kaltura.atlassian.net/browse/FEC-14353)

[FEC-14353]: https://kaltura.atlassian.net/browse/FEC-14353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ