### PR TITLE
fix(FEC-14441): live view analytic - fix absolutePosition

### DIFF
--- a/src/kaltura-live-plugin.tsx
+++ b/src/kaltura-live-plugin.tsx
@@ -46,6 +46,11 @@ export enum KalturaEntryServerNodeStatus {
   taskUploading = 8
 }
 
+interface PrevAbsolutePositionData {
+  position: number | null;
+  updatedAt: number;
+}
+
 // @ts-ignore
 export class KalturaLivePlugin extends KalturaPlayer.core.BasePlugin implements IMiddlewareProvider, IEngineDecoratorProvider {
   public player: KalturaPlayerTypes.Player;
@@ -64,6 +69,7 @@ export class KalturaLivePlugin extends KalturaPlayer.core.BasePlugin implements 
   private _preOfflinePlayer: any = null;
   private _postOfflinePlayer: any = null;
   private _liveViewersManager: LiveViewersManager | null = null;
+  private _prevPositionData: PrevAbsolutePositionData = { position: null, updatedAt: 0 };
 
   static defaultConfig: LivePluginConfig = {
     checkLiveWithKs: false,
@@ -281,8 +287,20 @@ export class KalturaLivePlugin extends KalturaPlayer.core.BasePlugin implements 
   }
 
   private _tamperAnalyticsHandler = (e: any) => {
-    if (this._absolutePosition) {
+    const updatePosition = () => {
       e.absolutePosition = this._absolutePosition;
+      this._prevPositionData = {
+        position: this._absolutePosition,
+        updatedAt: this.player.currentTime
+      };
+    };
+
+    if (this._absolutePosition && this._absolutePosition !== this._prevPositionData.position) {
+      updatePosition();
+    } else if (this._absolutePosition && this._prevPositionData.updatedAt !== this.player.currentTime) {
+      const deltaSec = Math.floor(this.player.currentTime - this._prevPositionData.updatedAt);
+      this._absolutePosition += (deltaSec * 1000); // absolute position is in ms - convert delta seconds to ms
+      updatePosition();
     }
     return true;
   };

--- a/src/kaltura-live-plugin.tsx
+++ b/src/kaltura-live-plugin.tsx
@@ -525,6 +525,7 @@ export class KalturaLivePlugin extends KalturaPlayer.core.BasePlugin implements 
     this.eventManager.unlisten(this.player, this.player.Event.TIMED_METADATA, this.handleTimedMetadata);
     this.eventManager.unlisten(this.player, this.player.Event.MEDIA_LOADED, this._handleMediaLoaded);
     this._liveViewersManager?.reset();
+    this._prevPositionData = { position: null, updatedAt: 0 };
   }
 
   destroy(): void {


### PR DESCRIPTION
**Description of the issue:**

`absolutePosition` is not being updated as expected which implies that the user haven’t watched the live video (even though they have).

**Technical explanation:**
- `VIEW` event is sent by kava plugin every 10 seconds
- in case of live playback, the kava dashboard is looking at `absolutePosition`, which represents the time when the view event was sent, in epoch
- the `absolutePosition` is taken from kaltura-live plugin; it is being calculated inside a callback function of a listener of `TIMED_METADATA` event
- in some cases (inconsistently), the `TIMED_METADATA` event is not being triggered (responsibility of engine video element)
- this is causing the issue where the `absolutePosition` is not being updated as expected

**Solution:**
assumption - `player.currentTime` is progressing even though the `absolutePosition` isn’t (even between refreshes; tested both on Chrome and Safari browsers).
- tracking a `previousAbsolutePosition` that was sent, and the `player.currentTime` when it was sent
- when kava plugin will try to get the `absolutePosition` from kaltura-live plugin (on `view` event), the kaltura-live plugin will check:
in case the `absolutePosition` is the same as the previous one (which means it is stuck) - we will manually fix and correct the value according to the `player.currentTime`
- calculating the delta of `player.currentTime - prev.currentTime` and adding it to the `absolutePosition`

Solves [FEC-14441](https://kaltura.atlassian.net/browse/FEC-14441)

[FEC-14441]: https://kaltura.atlassian.net/browse/FEC-14441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ